### PR TITLE
Restrict committing to "main" branch, organization member

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-1. Test that an organization member (Martins-23) can commit to a public repository, on the "main" branch.
-2. Test that the organization owner (Martins-33) can commit to a public repository, on the "main" branch.
-3. Test that an organization member (Martins-23) cannot commit now directly to the "main" branch, but needs to create a PR, and that one also needs at least one approval.
-    3.1. By setting an organization rule
+1. Test that an organization member (Martins-23) can commit to a public repository, on the "main" branch.  
+2. Test that the organization owner (Martins-33) can commit to a public repository, on the "main" branch.  
+3. Test that an organization member (Martins-23) cannot commit now directly to the "main" branch, but needs to create a PR, and that one also needs at least one approval.  
+    3.1. By setting an organization rule.  
+    3.2. By setting a repository-specific rule.  


### PR DESCRIPTION
A repository-specific rule has been used.