### PR TITLE
Restrict committing to "main" branch, organization owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 3. Test that an organization member (Martins-23) cannot commit now directly to the "main" branch, but needs to create a PR, and that one also needs at least one approval.  
     3.1. By setting an organization rule.  
     3.2. By setting a repository-specific rule.  
+4. Test that an organization owner (Martins-33) cannot commit now directly to the "main" branch, but needs to create a PR, and that one also needs at least one approval.  


### PR DESCRIPTION
A repository-specific rule has been used.